### PR TITLE
Features/outbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,22 @@
             <version>1.6.11</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/common/DomainEvent.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/common/DomainEvent.java
@@ -1,4 +1,6 @@
 package com.whataplabs.task.order.whataplabstaskorder.application.event.common;
 
 public interface DomainEvent {
+    EventType getEventType();
+    String getPayload();
 }

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/common/EventType.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/common/EventType.java
@@ -1,0 +1,8 @@
+package com.whataplabs.task.order.whataplabstaskorder.application.event.common;
+
+public enum EventType {
+    ORDER_REQUESTED,
+    ORDER_CHANGE_REQUESTED,
+    ORDER_CANCEL_REQUESTED,
+    ;
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/listener/OutboxEventListener.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/listener/OutboxEventListener.java
@@ -11,9 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.LocalDateTime;
 
@@ -25,7 +26,7 @@ public class OutboxEventListener {
     private final ApplicationEventPublisher publisher;
 
     @Async
-    @EventListener({ApplicationReadyEvent.class, OutboxCreated.class})
+    @TransactionalEventListener(value = {ApplicationReadyEvent.class, OutboxCreated.class}, phase = TransactionPhase.AFTER_COMMIT)
     public void deliveryOutboxEvents() {
         log.debug("[deliveryOutboxEvents] START {}", LocalDateTime.now());
         while (true) {

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/listener/OutboxEventListener.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/event/listener/OutboxEventListener.java
@@ -1,0 +1,53 @@
+package com.whataplabs.task.order.whataplabstaskorder.application.event.listener;
+
+import com.whataplabs.task.order.whataplabstaskorder.domain.OrderCancelRequested;
+import com.whataplabs.task.order.whataplabstaskorder.domain.OrderChangeRequested;
+import com.whataplabs.task.order.whataplabstaskorder.domain.OrderRequested;
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.Outbox;
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.OutboxCreated;
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.OutboxRepository;
+import com.whataplabs.task.order.whataplabstaskorder.infrastructure.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventListener {
+    private final OutboxRepository outboxRepository;
+    private final ApplicationEventPublisher publisher;
+
+    @Async
+    @EventListener({ApplicationReadyEvent.class, OutboxCreated.class})
+    public void deliveryOutboxEvents() {
+        log.debug("[deliveryOutboxEvents] START {}", LocalDateTime.now());
+        while (true) {
+            Outbox outbox = outboxRepository.popOutbox();
+
+            if (outbox == null) {
+                break;
+            }
+
+            switch (outbox.getEventType()) {
+                case ORDER_REQUESTED -> publisher.publishEvent(makeEvent(outbox.getPayload(), OrderRequested.class));
+                case ORDER_CHANGE_REQUESTED -> publisher.publishEvent(makeEvent(outbox.getPayload(), OrderChangeRequested.class));
+                case ORDER_CANCEL_REQUESTED -> publisher.publishEvent(makeEvent(outbox.getPayload(), OrderCancelRequested.class));
+            }
+
+            outboxRepository.removeOutbox(outbox);
+            log.debug("[deliveryOutboxEvents] END {}", LocalDateTime.now());
+        }
+    }
+
+    private <T> T makeEvent(String payload, Class<T> clazz) {
+        return JsonUtil.fromJson(payload, clazz);
+    }
+
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/service/OrderService.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/service/OrderService.java
@@ -2,10 +2,11 @@ package com.whataplabs.task.order.whataplabstaskorder.application.service;
 
 import com.whataplabs.task.order.whataplabstaskorder.domain.*;
 import com.whataplabs.task.order.whataplabstaskorder.domain.exception.OrderNotFoundException;
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.DomainEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -17,7 +18,7 @@ import static com.whataplabs.task.order.whataplabstaskorder.domain.OrderStatus.O
 public class OrderService {
     private final OrderRepository repository;
 
-    private final ApplicationEventPublisher publisher;
+    private final DomainEventPublisher publisher;
 
     public Order getOrder(Long orderId) {
         return repository.getOrder(orderId)
@@ -30,24 +31,26 @@ public class OrderService {
 
     public Order orderProducts(Order newOrder) {
         Order order = repository.orderProducts(newOrder);
-        publisher.publishEvent(new OrderRequested(order));
+        publisher.publish(new OrderRequested(order));
         return order;
     }
 
+    @Transactional
     public Order changeOrder(Order changeOrder) {
         Order originOrder = getOrder(changeOrder.getId());
         originOrder.checkCanChange(changeOrder);
         updateOrderStatus(originOrder.getId(), changeOrder.getStatus());
 
-        publisher.publishEvent(OrderChangeRequested.of(originOrder, changeOrder));
+        publisher.publish(OrderChangeRequested.of(originOrder, changeOrder));
         return changeOrder;
     }
 
+    @Transactional
     public Order cancelOrder(Long orderId) {
         updateOrderStatus(orderId, ORDER_CANCEL_REQUEST);
 
         Order order = getOrder(orderId);
-        publisher.publishEvent(new OrderCancelRequested(order));
+        publisher.publish(new OrderCancelRequested(order));
         return order;
     }
 

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/service/OrderService.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/service/OrderService.java
@@ -6,7 +6,6 @@ import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.DomainEventPu
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -35,7 +34,6 @@ public class OrderService {
         return order;
     }
 
-    @Transactional
     public Order changeOrder(Order changeOrder) {
         Order originOrder = getOrder(changeOrder.getId());
         originOrder.checkCanChange(changeOrder);
@@ -45,7 +43,6 @@ public class OrderService {
         return changeOrder;
     }
 
-    @Transactional
     public Order cancelOrder(Long orderId) {
         updateOrderStatus(orderId, ORDER_CANCEL_REQUEST);
 

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/service/OrderService.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/application/service/OrderService.java
@@ -6,6 +6,7 @@ import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.DomainEventPu
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -28,12 +29,14 @@ public class OrderService {
         return repository.getOrders();
     }
 
+    @Transactional
     public Order orderProducts(Order newOrder) {
         Order order = repository.orderProducts(newOrder);
         publisher.publish(new OrderRequested(order));
         return order;
     }
 
+    @Transactional
     public Order changeOrder(Order changeOrder) {
         Order originOrder = getOrder(changeOrder.getId());
         originOrder.checkCanChange(changeOrder);
@@ -43,6 +46,7 @@ public class OrderService {
         return changeOrder;
     }
 
+    @Transactional
     public Order cancelOrder(Long orderId) {
         updateOrderStatus(orderId, ORDER_CANCEL_REQUEST);
 

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderCancelRequested.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderCancelRequested.java
@@ -1,8 +1,19 @@
 package com.whataplabs.task.order.whataplabstaskorder.domain;
 
 import com.whataplabs.task.order.whataplabstaskorder.application.event.common.DomainEvent;
+import com.whataplabs.task.order.whataplabstaskorder.application.event.common.EventType;
+import com.whataplabs.task.order.whataplabstaskorder.infrastructure.util.JsonUtil;
 
 public record OrderCancelRequested(
         Order order
 ) implements DomainEvent {
+    @Override
+    public EventType getEventType() {
+        return EventType.ORDER_CANCEL_REQUESTED;
+    }
+
+    @Override
+    public String getPayload() {
+        return "{\"order\":" + JsonUtil.toJson(order) + "}";
+    }
 }

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderChangeRequested.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderChangeRequested.java
@@ -1,6 +1,8 @@
 package com.whataplabs.task.order.whataplabstaskorder.domain;
 
 import com.whataplabs.task.order.whataplabstaskorder.application.event.common.DomainEvent;
+import com.whataplabs.task.order.whataplabstaskorder.application.event.common.EventType;
+import com.whataplabs.task.order.whataplabstaskorder.infrastructure.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,5 +26,20 @@ public record OrderChangeRequested(
                     .ifPresentOrElse(o -> products.add(c.changeQuantity(o.getQuantity())), () -> products.add(c));
         }
         return Order.builder().id(orderId).orderProducts(products).build();
+    }
+
+    @Override
+    public EventType getEventType() {
+        return EventType.ORDER_CHANGE_REQUESTED;
+    }
+
+    @Override
+    public String getPayload() {
+        return "{" +
+                "\"orderId\":" + "\"" + orderId + "\"," +
+                "\"originStatus\":" + "\"" + originStatus + "\"," +
+                "\"origin\":" + JsonUtil.toJson(origin) + "," +
+                "\"change\":" + JsonUtil.toJson(change) +
+                "}";
     }
 }

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderProduct.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderProduct.java
@@ -1,5 +1,6 @@
 package com.whataplabs.task.order.whataplabstaskorder.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class OrderProduct {
         this.lastModifiedAt = lastModifiedAt;
     }
 
+    @JsonIgnore
     public BigDecimal getOrderPrice() {
         return unitPrice.multiply(BigDecimal.valueOf(quantity));
     }

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderRequested.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/OrderRequested.java
@@ -1,8 +1,19 @@
 package com.whataplabs.task.order.whataplabstaskorder.domain;
 
 import com.whataplabs.task.order.whataplabstaskorder.application.event.common.DomainEvent;
+import com.whataplabs.task.order.whataplabstaskorder.application.event.common.EventType;
+import com.whataplabs.task.order.whataplabstaskorder.infrastructure.util.JsonUtil;
 
 public record OrderRequested(
         Order order
 ) implements DomainEvent {
+    @Override
+    public EventType getEventType() {
+        return EventType.ORDER_REQUESTED;
+    }
+
+    @Override
+    public String getPayload() {
+        return "{\"order\":" + JsonUtil.toJson(order) + "}";
+    }
 }

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/DomainEventPublisher.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/DomainEventPublisher.java
@@ -1,0 +1,30 @@
+package com.whataplabs.task.order.whataplabstaskorder.domain.outbox;
+
+import com.whataplabs.task.order.whataplabstaskorder.application.event.common.DomainEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DomainEventPublisher {
+    private final ApplicationEventPublisher publisher;
+    private final OutboxRepository repository;
+
+    @Transactional
+    public void publish(DomainEvent event) {
+        Outbox outbox = Outbox.builder()
+                .eventType(event.getEventType())
+                .payload(event.getPayload())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        repository.pushOutbox(outbox);
+        publisher.publishEvent(new OutboxCreated());
+    }
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/DomainEventPublisher.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/DomainEventPublisher.java
@@ -18,6 +18,8 @@ public class DomainEventPublisher {
 
     @Transactional
     public void publish(DomainEvent event) {
+        log.info("[DomainEventPublisher.publish] event occurred. event={}, payload={}", event.getEventType(), event.getPayload());
+
         Outbox outbox = Outbox.builder()
                 .eventType(event.getEventType())
                 .payload(event.getPayload())

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/Outbox.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/Outbox.java
@@ -1,0 +1,17 @@
+package com.whataplabs.task.order.whataplabstaskorder.domain.outbox;
+
+import com.whataplabs.task.order.whataplabstaskorder.application.event.common.EventType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Outbox {
+    private Long id;
+    private EventType eventType;
+    private String payload;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/OutboxCreated.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/OutboxCreated.java
@@ -1,0 +1,4 @@
+package com.whataplabs.task.order.whataplabstaskorder.domain.outbox;
+
+public record OutboxCreated() {
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/OutboxRepository.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/domain/outbox/OutboxRepository.java
@@ -1,0 +1,7 @@
+package com.whataplabs.task.order.whataplabstaskorder.domain.outbox;
+
+public interface OutboxRepository {
+    void pushOutbox(Outbox outbox);
+    Outbox popOutbox();
+    void removeOutbox(Outbox outbox);
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxEntity.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxEntity.java
@@ -1,0 +1,37 @@
+package com.whataplabs.task.order.whataplabstaskorder.infrastructure.repository.outbox;
+
+import com.whataplabs.task.order.whataplabstaskorder.application.event.common.EventType;
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.Outbox;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox")
+public class OutboxEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(value = EnumType.STRING)
+    private EventType eventType;
+    private String payload;
+    private LocalDateTime createdAt;
+
+    public static OutboxEntity create(Outbox outbox) {
+        OutboxEntity outboxEntity = new OutboxEntity();
+        outboxEntity.eventType = outbox.getEventType();
+        outboxEntity.payload = outbox.getPayload();
+        outboxEntity.createdAt = LocalDateTime.now();
+        return outboxEntity;
+    }
+
+    public Outbox toDomain() {
+        return Outbox.builder()
+                .id(id)
+                .eventType(eventType)
+                .payload(payload)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxHistoryEntity.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxHistoryEntity.java
@@ -1,0 +1,31 @@
+package com.whataplabs.task.order.whataplabstaskorder.infrastructure.repository.outbox;
+
+import com.whataplabs.task.order.whataplabstaskorder.application.event.common.EventType;
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.Outbox;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox_history")
+public class OutboxHistoryEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long outboxId;
+    @Enumerated(value = EnumType.STRING)
+    private EventType eventType;
+    private String payload;
+
+    private LocalDateTime createdAt;
+
+    public static OutboxHistoryEntity create(Outbox outbox) {
+        OutboxHistoryEntity entity = new OutboxHistoryEntity();
+        entity.outboxId = outbox.getId();
+        entity.eventType = outbox.getEventType();
+        entity.payload = outbox.getPayload();
+        entity.createdAt = LocalDateTime.now();
+        return entity;
+    }
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxHistoryJpaRepository.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxHistoryJpaRepository.java
@@ -1,0 +1,6 @@
+package com.whataplabs.task.order.whataplabstaskorder.infrastructure.repository.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxHistoryJpaRepository extends JpaRepository<OutboxHistoryEntity, Long> {
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxJpaRepository.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxJpaRepository.java
@@ -1,0 +1,9 @@
+package com.whataplabs.task.order.whataplabstaskorder.infrastructure.repository.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, Long> {
+    Optional<OutboxEntity> findFirstByOrderByIdAsc();
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxRepositoryImpl.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/repository/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.whataplabs.task.order.whataplabstaskorder.infrastructure.repository.outbox;
+
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.Outbox;
+import com.whataplabs.task.order.whataplabstaskorder.domain.outbox.OutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+    private final OutboxJpaRepository jpaRepository;
+    private final OutboxHistoryJpaRepository historyJpaRepository;
+
+    @Override
+    @Transactional
+    public void pushOutbox(Outbox outbox) {
+        jpaRepository.save(OutboxEntity.create(outbox));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Outbox popOutbox() {
+        return jpaRepository.findFirstByOrderByIdAsc()
+                .map(OutboxEntity::toDomain).orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public void removeOutbox(Outbox outbox) {
+        historyJpaRepository.save(OutboxHistoryEntity.create(outbox));
+        jpaRepository.deleteById(outbox.getId());
+    }
+}

--- a/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/util/JsonUtil.java
+++ b/src/main/java/com/whataplabs/task/order/whataplabstaskorder/infrastructure/util/JsonUtil.java
@@ -1,0 +1,34 @@
+package com.whataplabs.task.order.whataplabstaskorder.infrastructure.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class JsonUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    static {
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    public static String toJson(Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            log.error("[JsonUtil.toJson] {}", e.getMessage());
+            return StringUtils.EMPTY;
+        }
+    }
+
+    public static <T> T fromJson(String json, Class<T> valueType) {
+        try {
+            return objectMapper.readValue(json, valueType);
+        } catch (JsonProcessingException e) {
+            log.error("[JsonUtil.fromJson] {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,9 @@
 DROP TABLE IF EXISTS ORDER_PRODUCT;
 DROP TABLE IF EXISTS ORDERS;
 
+DROP TABLE IF EXISTS OUTBOX_HISTORY;
+DROP TABLE IF EXISTS OUTBOX;
+
 -- CREATE ORDERS TABLE
 CREATE TABLE ORDERS (
     order_id bigint AUTO_INCREMENT NOT NULL,
@@ -21,4 +24,23 @@ CREATE TABLE ORDER_PRODUCT (
     created_at timestamp default now(),
     last_modified_at timestamp,
     primary key (order_product_id)
+);
+
+-- CREATE OUTBOX TABLE
+CREATE TABLE OUTBOX (
+    id bigint AUTO_INCREMENT NOT NULL,
+    event_type varchar(50) NOT NULL,
+    payload varchar(1024),
+    created_at timestamp default now(),
+    primary key (id)
+);
+
+-- CREATE OUTBOX_HISTORY TABLE
+CREATE TABLE OUTBOX_HISTORY (
+    id bigint AUTO_INCREMENT NOT NULL,
+    outbox_id bigint NOT NULL,
+    event_type varchar(50) NOT NULL,
+    payload varchar(1024),
+    created_at timestamp default now(),
+    primary key (id)
 );


### PR DESCRIPTION
### overview
이벤트 발행 시 바로 이벤트를 발행하기 보다 Outbox 형태로 DB에 저장한 뒤, 해당 이벤트를 발행 시키는 방식으로 수정

### 작업 내용
- 주문 요청, 변경 요청, 취소 요청 시 각 이벤트 데이터를 outbox 형태로 만들어 DB에 저장하고 ```OutboxCreated``` 이벤트 발행 (여기까지 이전 트랜잭션으로 묶임)
-  ```@TransactionalEventListener```를 통해 outbox 테이블에 저장된 이벤트 객체를 찾아 각 기능에 맞는 이벤트를 비동기로 처리
- outbox 테이블에서 데이터를 읽어 각 이벤트에 맞는 처리를 하고 나면 outbox_history에 해당 데이터를 추가하고 outbox 테이블에서는 삭제

### 추가 고려 사항
- Outbox 이벤트를 읽고 처리를 비동기로 하기 때문에 데이터 손실이 생길 것을 대비해 outbox_history 테이블에 데이터를 쌓아두었는데
- 이벤트 큐 같은 곳에 produce 하고 outbox에서 데이터를 지워 재처리가 별도 큐로 동작할 수 있게 하는 것이 더 좋을 것 같습니다.
- Kafka 등의 이벤트 큐를 사용하는 방식은 이번 코드에서 제외하였습니다.